### PR TITLE
Add support for custom json encoding flags

### DIFF
--- a/jsonlines/__init__.py
+++ b/jsonlines/__init__.py
@@ -9,4 +9,5 @@ from .jsonlines import (  # noqa
     open,
     Error,
     InvalidLineError,
+    InvalidJsonArguments,
 )

--- a/tests/test_jsonlines.py
+++ b/tests/test_jsonlines.py
@@ -28,6 +28,22 @@ def test_writer():
     assert fp.getvalue() == SAMPLE_BYTES
 
 
+def test_writer_json_kwargs():
+    fp = io.BytesIO()
+    with jsonlines.Writer(fp, sort_keys=True, separators=(',', ':')) as writer:
+        writer.write({'b': 2, 'a': 1})
+        writer.write({'c': 3, 'd': 4})
+    assert fp.getvalue() == b'{"a":1,"b":2}\n{"c":3,"d":4}\n'
+
+
+def test_writer_json_kwargs_invalid():
+    with pytest.raises(jsonlines.InvalidJsonArguments):
+        jsonlines.Writer(io.BytesIO(), indent=2)
+
+    with pytest.raises(jsonlines.InvalidJsonArguments):
+        jsonlines.Writer(io.BytesIO(), separators=(',\n', ':'))
+
+
 def test_invalid_lines():
     data = u'[1, 2'
     with jsonlines.Reader(io.StringIO(data)) as reader:


### PR DESCRIPTION
By default, the Python json serializer adds extra white-space around the item and key separators. This behavior increases the size of the jsonl files created by this library. A nice use-case for the jsonl format is dealing with large amounts of data so it would be great to be able to specify item and key separators without the extra white-space in this library to save a little bit of space.

This PR adds the ability to pass-through arguments to the underlying json serializer used by jsonlines to support the aforementioned use-case.

Resolves #10