### PR TITLE
Add support for Python 3.8, drop EOL 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ matrix:
   include:
   - python: "3.7"
     env: TOXENV=flake8
+  - python: "3.8"
+    env: TOXENV=py38
   - python: "3.7"
     env: TOXENV=py37
   - python: "3.6"
     env: TOXENV=py36
   - python: "3.5"
     env: TOXENV=py35
-  - python: "3.4"
-    env: TOXENV=py34
   - python: "2.7"
     env: TOXENV=py27
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -62,7 +62,7 @@ Installation
 
   pip install jsonlines
 
-The supported Python versions are 3.3+ and Python 2.7.
+The supported Python versions are 3.5+ and Python 2.7.
 
 
 User guide

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,flake8
+envlist = py27,py35,py36,py37,py38,flake8
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Here's the pip installs for jsonlines from PyPI for January 2020:

| category | percent | downloads |
|----------|--------:|----------:|
| 3.6      |  43.90% |    52,117 |
| 3.7      |  38.68% |    45,923 |
| 3.5      |   7.98% |     9,477 |
| 2.7      |   6.52% |     7,735 |
| 3.8      |   2.47% |     2,930 |
| null     |   0.24% |       288 |
| 3.4      |   0.21% |       247 |
| 2.6      |   0.01% |         6 |
| Total    |         |   118,723 |

Source: `pip install -U pypistats && pypistats python_minor jsonlines --last-month`