### PR TITLE
Add conda badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@
 .. image:: https://pepy.tech/badge/jsonlines/month
    :target: https://pepy.tech/project/jsonlines
 
+.. image:: https://anaconda.org/anaconda/anaconda/badges/installer/conda.svg
+   :target: https://anaconda.org/anaconda/jsonlines
+
 =========
 jsonlines
 =========


### PR DESCRIPTION
There are multiple badge versions. I added one but those are the others:

https://anaconda.org/anaconda/jsonlines/badges

and

https://shields.io/category/downloads (Everything under conda, overview is here: https://github.com/conda-forge/jsonlines-feedstock)

I can add whichever you like the most.

Closes #56 