### PR TITLE
Annotate open() to enable type checking and IDE suggestions

### DIFF
--- a/jsonlines/jsonlines.py
+++ b/jsonlines/jsonlines.py
@@ -3,7 +3,6 @@ jsonlines implementation
 """
 
 import builtins
-import io
 import json
 import numbers
 
@@ -74,59 +73,6 @@ class ReaderWriterBase:
         if self._should_close_fp:
             self._fp.close()
 
-    def read(self, type=None, allow_none=False, skip_empty=False):
-        """
-        Read and decode a line.
-
-        The optional `type` argument specifies the expected data type.
-        Supported types are ``dict``, ``list``, ``str``, ``int``,
-        ``float``, ``numbers.Number`` (accepts both integers and
-        floats), and ``bool``. When specified, non-conforming lines
-        result in :py:exc:`InvalidLineError`.
-
-        By default, input lines containing ``null`` (in JSON) are
-        considered invalid, and will cause :py:exc:`InvalidLineError`.
-        The `allow_none` argument can be used to change this behaviour,
-        in which case ``None`` will be returned instead.
-
-        If `skip_empty` is set to ``True``, empty lines and lines
-        containing only whitespace are silently skipped.
-        """
-        raise NotImplementedError()
-
-    def iter(self, type=None, allow_none=False, skip_empty=False, skip_invalid=False):
-        """
-        Iterate over all lines.
-
-        This is the iterator equivalent to repeatedly calling
-        :py:meth:`~Reader.read()`. If no arguments are specified, this
-        is the same as directly iterating over this :py:class:`Reader`
-        instance.
-
-        When `skip_invalid` is set to ``True``, invalid lines will be
-        silently ignored.
-
-        See :py:meth:`~Reader.read()` for a description of the other
-        arguments.
-        """
-        raise NotImplementedError()
-
-    def write(self, obj):
-        """
-        Encode and write a single object.
-
-        :param obj: the object to encode and write
-        """
-        raise NotImplementedError()
-
-    def write_all(self, iterable):
-        """
-        Encode and write multiple objects.
-
-        :param iterable: an iterable of objects
-        """
-        raise NotImplementedError()
-
     def __repr__(self):
         name = getattr(self._fp, "name", None)
         if name:
@@ -174,6 +120,23 @@ class Reader(ReaderWriterBase):
         self._line_iter = enumerate(iterable, 1)
 
     def read(self, type=None, allow_none=False, skip_empty=False):
+        """
+        Read and decode a line.
+
+        The optional `type` argument specifies the expected data type.
+        Supported types are ``dict``, ``list``, ``str``, ``int``,
+        ``float``, ``numbers.Number`` (accepts both integers and
+        floats), and ``bool``. When specified, non-conforming lines
+        result in :py:exc:`InvalidLineError`.
+
+        By default, input lines containing ``null`` (in JSON) are
+        considered invalid, and will cause :py:exc:`InvalidLineError`.
+        The `allow_none` argument can be used to change this behaviour,
+        in which case ``None`` will be returned instead.
+
+        If `skip_empty` is set to ``True``, empty lines and lines
+        containing only whitespace are silently skipped.
+        """
         if self._closed:
             raise RuntimeError("reader is closed")
         if type is not None and type not in VALID_TYPES:
@@ -220,6 +183,20 @@ class Reader(ReaderWriterBase):
         return value
 
     def iter(self, type=None, allow_none=False, skip_empty=False, skip_invalid=False):
+        """
+        Iterate over all lines.
+
+        This is the iterator equivalent to repeatedly calling
+        :py:meth:`~Reader.read()`. If no arguments are specified, this
+        is the same as directly iterating over this :py:class:`Reader`
+        instance.
+
+        When `skip_invalid` is set to ``True``, invalid lines will be
+        silently ignored.
+
+        See :py:meth:`~Reader.read()` for a description of the other
+        arguments.
+        """
         try:
             while True:
                 try:
@@ -231,12 +208,6 @@ class Reader(ReaderWriterBase):
                         raise
         except EOFError:
             pass
-
-    def write(self, obj):
-        raise io.UnsupportedOperation("not writable")
-
-    def write_all(self, iterable):
-        raise io.UnsupportedOperation("not writable")
 
     def __iter__(self):
         """
@@ -318,12 +289,6 @@ class Writer(ReaderWriterBase):
         """
         for obj in iterable:
             self.write(obj)
-
-    def read(self, type=None, allow_none=False, skip_empty=False):
-        raise io.UnsupportedOperation("not readable")
-
-    def iter(self, type=None, allow_none=False, skip_empty=False, skip_invalid=False):
-        raise io.UnsupportedOperation("not readable")
 
 
 def open(name, mode="r", **kwargs):

--- a/jsonlines/jsonlines.py
+++ b/jsonlines/jsonlines.py
@@ -344,6 +344,7 @@ def open(name, mode="r", **kwargs) -> Union[Reader, Writer]:
     if mode not in {"r", "w", "a"}:
         raise ValueError("'mode' must be either 'r', 'w', or 'a'")
     fp = builtins.open(name, mode=mode + "t", encoding="utf-8")
+    instance: Union[Reader, Writer]
     if mode == "r":
         instance = Reader(fp, **kwargs)
     else:

--- a/jsonlines/jsonlines.py
+++ b/jsonlines/jsonlines.py
@@ -5,8 +5,18 @@ jsonlines implementation
 import builtins
 import json
 import numbers
-from typing import Union
+import os
+import sys
+from typing import Union, overload
 
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+
+# https://docs.python.org/3/library/functions.html#open
+_Openable = Union[str, bytes, int, os.PathLike]
 
 VALID_TYPES = {
     bool,
@@ -295,27 +305,17 @@ class Writer(ReaderWriterBase):
             self.write(obj)
 
 
-try:
-    from typing import Literal, overload
-
-    @overload
-    def open(name, **kwargs) -> Reader:
-        ...
-
-    @overload
-    def open(name, mode: Literal["r"], **kwargs) -> Reader:
-        ...
-
-    @overload
-    def open(name, mode: Literal["w", "a"], **kwargs) -> Writer:
-        ...
+@overload
+def open(file: _Openable, mode: Literal["r"], **kwargs) -> Reader:
+    ...
 
 
-except ImportError:
-    pass
+@overload
+def open(file: _Openable, mode: Literal["w", "a"], **kwargs) -> Writer:
+    ...
 
 
-def open(file, mode="r", **kwargs) -> Union[Reader, Writer]:
+def open(file: _Openable, mode="r", **kwargs) -> Union[Reader, Writer]:
     """
     Open a jsonlines file for reading or writing.
 

--- a/jsonlines/jsonlines.py
+++ b/jsonlines/jsonlines.py
@@ -3,6 +3,7 @@ jsonlines implementation
 """
 
 import builtins
+import io
 import json
 import numbers
 
@@ -73,6 +74,59 @@ class ReaderWriterBase:
         if self._should_close_fp:
             self._fp.close()
 
+    def read(self, type=None, allow_none=False, skip_empty=False):
+        """
+        Read and decode a line.
+
+        The optional `type` argument specifies the expected data type.
+        Supported types are ``dict``, ``list``, ``str``, ``int``,
+        ``float``, ``numbers.Number`` (accepts both integers and
+        floats), and ``bool``. When specified, non-conforming lines
+        result in :py:exc:`InvalidLineError`.
+
+        By default, input lines containing ``null`` (in JSON) are
+        considered invalid, and will cause :py:exc:`InvalidLineError`.
+        The `allow_none` argument can be used to change this behaviour,
+        in which case ``None`` will be returned instead.
+
+        If `skip_empty` is set to ``True``, empty lines and lines
+        containing only whitespace are silently skipped.
+        """
+        raise NotImplementedError()
+
+    def iter(self, type=None, allow_none=False, skip_empty=False, skip_invalid=False):
+        """
+        Iterate over all lines.
+
+        This is the iterator equivalent to repeatedly calling
+        :py:meth:`~Reader.read()`. If no arguments are specified, this
+        is the same as directly iterating over this :py:class:`Reader`
+        instance.
+
+        When `skip_invalid` is set to ``True``, invalid lines will be
+        silently ignored.
+
+        See :py:meth:`~Reader.read()` for a description of the other
+        arguments.
+        """
+        raise NotImplementedError()
+
+    def write(self, obj):
+        """
+        Encode and write a single object.
+
+        :param obj: the object to encode and write
+        """
+        raise NotImplementedError()
+
+    def write_all(self, iterable):
+        """
+        Encode and write multiple objects.
+
+        :param iterable: an iterable of objects
+        """
+        raise NotImplementedError()
+
     def __repr__(self):
         name = getattr(self._fp, "name", None)
         if name:
@@ -120,23 +174,6 @@ class Reader(ReaderWriterBase):
         self._line_iter = enumerate(iterable, 1)
 
     def read(self, type=None, allow_none=False, skip_empty=False):
-        """
-        Read and decode a line.
-
-        The optional `type` argument specifies the expected data type.
-        Supported types are ``dict``, ``list``, ``str``, ``int``,
-        ``float``, ``numbers.Number`` (accepts both integers and
-        floats), and ``bool``. When specified, non-conforming lines
-        result in :py:exc:`InvalidLineError`.
-
-        By default, input lines containing ``null`` (in JSON) are
-        considered invalid, and will cause :py:exc:`InvalidLineError`.
-        The `allow_none` argument can be used to change this behaviour,
-        in which case ``None`` will be returned instead.
-
-        If `skip_empty` is set to ``True``, empty lines and lines
-        containing only whitespace are silently skipped.
-        """
         if self._closed:
             raise RuntimeError("reader is closed")
         if type is not None and type not in VALID_TYPES:
@@ -183,20 +220,6 @@ class Reader(ReaderWriterBase):
         return value
 
     def iter(self, type=None, allow_none=False, skip_empty=False, skip_invalid=False):
-        """
-        Iterate over all lines.
-
-        This is the iterator equivalent to repeatedly calling
-        :py:meth:`~Reader.read()`. If no arguments are specified, this
-        is the same as directly iterating over this :py:class:`Reader`
-        instance.
-
-        When `skip_invalid` is set to ``True``, invalid lines will be
-        silently ignored.
-
-        See :py:meth:`~Reader.read()` for a description of the other
-        arguments.
-        """
         try:
             while True:
                 try:
@@ -208,6 +231,12 @@ class Reader(ReaderWriterBase):
                         raise
         except EOFError:
             pass
+
+    def write(self, obj):
+        raise io.UnsupportedOperation("not writable")
+
+    def write_all(self, iterable):
+        raise io.UnsupportedOperation("not writable")
 
     def __iter__(self):
         """
@@ -289,6 +318,12 @@ class Writer(ReaderWriterBase):
         """
         for obj in iterable:
             self.write(obj)
+
+    def read(self, type=None, allow_none=False, skip_empty=False):
+        raise io.UnsupportedOperation("not readable")
+
+    def iter(self, type=None, allow_none=False, skip_empty=False, skip_invalid=False):
+        raise io.UnsupportedOperation("not readable")
 
 
 def open(name, mode="r", **kwargs):

--- a/jsonlines/jsonlines.py
+++ b/jsonlines/jsonlines.py
@@ -315,7 +315,7 @@ except ImportError:
     pass
 
 
-def open(name, mode="r", **kwargs) -> Union[Reader, Writer]:
+def open(file, mode="r", **kwargs) -> Union[Reader, Writer]:
     """
     Open a jsonlines file for reading or writing.
 
@@ -336,14 +336,14 @@ def open(name, mode="r", **kwargs) -> Union[Reader, Writer]:
         with jsonlines.open('out.jsonl', mode='w') as writer:
             writer.write(...)
 
-    :param file-like fp: name of the file to open
-    :param str mode: whether to open the file for reading (``r``),
+    :param file: name or ‘path-like object’ of the file to open
+    :param mode: whether to open the file for reading (``r``),
         writing (``w``) or appending (``a``).
     :param **kwargs: additional arguments, forwarded to the reader or writer
     """
     if mode not in {"r", "w", "a"}:
         raise ValueError("'mode' must be either 'r', 'w', or 'a'")
-    fp = builtins.open(name, mode=mode + "t", encoding="utf-8")
+    fp = builtins.open(file, mode=mode + "t", encoding="utf-8")
     instance: Union[Reader, Writer]
     if mode == "r":
         instance = Reader(fp, **kwargs)

--- a/jsonlines/jsonlines.py
+++ b/jsonlines/jsonlines.py
@@ -5,6 +5,7 @@ jsonlines implementation
 import builtins
 import json
 import numbers
+from typing import Union
 
 
 VALID_TYPES = {
@@ -291,7 +292,27 @@ class Writer(ReaderWriterBase):
             self.write(obj)
 
 
-def open(name, mode="r", **kwargs):
+try:
+    from typing import Literal, overload
+
+    @overload
+    def open(name, **kwargs) -> Reader:
+        ...
+
+    @overload
+    def open(name, mode: Literal["r"], **kwargs) -> Reader:
+        ...
+
+    @overload
+    def open(name, mode: Literal["w", "a"], **kwargs) -> Writer:
+        ...
+
+
+except ImportError:
+    pass
+
+
+def open(name, mode="r", **kwargs) -> Union[Reader, Writer]:
     """
     Open a jsonlines file for reading or writing.
 

--- a/jsonlines/jsonlines.py
+++ b/jsonlines/jsonlines.py
@@ -306,7 +306,7 @@ class Writer(ReaderWriterBase):
 
 
 @overload
-def open(file: _Openable, mode: Literal["r"], **kwargs) -> Reader:
+def open(file: _Openable, mode: Literal["r"] = "r", **kwargs) -> Reader:
     ...
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,8 @@ classifiers =
 [options]
 packages = jsonlines
 python_requires = >=3.6
+install_requires =
+    typing_extensions; python_version < "3.8"
 
 [build_sphinx]
 source-dir = doc/

--- a/tests/test_jsonlines.py
+++ b/tests/test_jsonlines.py
@@ -196,3 +196,20 @@ def test_open_invalid_mode():
     with pytest.raises(ValueError) as excinfo:
         jsonlines.open("foo", mode="foo")
     assert "mode" in str(excinfo.value)
+
+
+def test_write_to_reader():
+    with tempfile.NamedTemporaryFile("w+b") as fp:
+        with jsonlines.open(fp.name) as reader:
+            with pytest.raises(io.UnsupportedOperation):
+                reader.write(1)
+            with pytest.raises(io.UnsupportedOperation):
+                reader.write_all([1, 2])
+
+
+def test_read_of_writer():
+    with jsonlines.open("foo", mode="w") as writer:
+        with pytest.raises(io.UnsupportedOperation):
+            writer.read()
+        with pytest.raises(io.UnsupportedOperation):
+            writer.iter()

--- a/tests/test_jsonlines.py
+++ b/tests/test_jsonlines.py
@@ -196,20 +196,3 @@ def test_open_invalid_mode():
     with pytest.raises(ValueError) as excinfo:
         jsonlines.open("foo", mode="foo")
     assert "mode" in str(excinfo.value)
-
-
-def test_write_to_reader():
-    with tempfile.NamedTemporaryFile("w+b") as fp:
-        with jsonlines.open(fp.name) as reader:
-            with pytest.raises(io.UnsupportedOperation):
-                reader.write(1)
-            with pytest.raises(io.UnsupportedOperation):
-                reader.write_all([1, 2])
-
-
-def test_read_of_writer():
-    with jsonlines.open("foo", mode="w") as writer:
-        with pytest.raises(io.UnsupportedOperation):
-            writer.read()
-        with pytest.raises(io.UnsupportedOperation):
-            writer.iter()


### PR DESCRIPTION
First, thanks for the package! Super useful.

This change moves reading and writing method definitions to `ReaderWriterBase` so IDEs can suggest methods when using the `jsonlines.open` convenience syntax. I follow `builtins.open` in raising an `io.UnsupportedOperation` exception when bad methods are called.

This may make the interface for `Reader` and `Writer` a little unintuitive, but this seems the cleanest way to do it. An alternative would be to keep `ReaderWriterBase` as is, and wrap responses from `.open` in a new parent class. Please let me know your thoughts - I'm happy to iterate, and just provide this to give an idea of what it'd look like.