### PR TITLE
Add type annotations; adopt mypy in strict mode

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,16 @@
+[mypy]
+check_untyped_defs = True
+disallow_any_generics = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+no_implicit_optional = True
+no_implicit_reexport = True
+show_error_codes = True
+strict_equality = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unused_configs = True
+warn_unused_ignores = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black
 flake8
+mypy
 pytest>=3
 pytest-cov
 sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
 packages = jsonlines
 python_requires = >=3.6
 install_requires =
+    attrs>=19.2.0
     typing_extensions; python_version < "3.8"
 
 [build_sphinx]

--- a/tests/test_jsonlines.py
+++ b/tests/test_jsonlines.py
@@ -4,9 +4,9 @@ Tests for the jsonlines library.
 
 import collections
 import io
-import jsonlines
 import tempfile
 
+import jsonlines
 import pytest
 
 
@@ -14,7 +14,7 @@ SAMPLE_BYTES = b'{"a": 1}\n{"b": 2}\n'
 SAMPLE_TEXT = SAMPLE_BYTES.decode("utf-8")
 
 
-def test_reader():
+def test_reader() -> None:
     fp = io.BytesIO(SAMPLE_BYTES)
     with jsonlines.Reader(fp) as reader:
         it = iter(reader)
@@ -26,19 +26,19 @@ def test_reader():
             reader.read()
 
 
-def test_reading_from_iterable():
+def test_reading_from_iterable() -> None:
     with jsonlines.Reader(["1", b"{}"]) as reader:
         assert list(reader) == [1, {}]
     assert "wrapping <list at " in repr(reader)
 
 
-def test_reader_rfc7464_text_sequences():
+def test_reader_rfc7464_text_sequences() -> None:
     fp = io.BytesIO(b'\x1e"a"\x0a\x1e"b"\x0a')
     with jsonlines.Reader(fp) as reader:
         assert list(reader) == ["a", "b"]
 
 
-def test_writer_text():
+def test_writer_text() -> None:
     fp = io.StringIO()
     with jsonlines.Writer(fp) as writer:
         writer.write({"a": 1})
@@ -46,7 +46,7 @@ def test_writer_text():
     assert fp.getvalue() == SAMPLE_TEXT
 
 
-def test_writer_binary():
+def test_writer_binary() -> None:
     fp = io.BytesIO()
     with jsonlines.Writer(fp) as writer:
         writer.write_all(
@@ -58,7 +58,7 @@ def test_writer_binary():
     assert fp.getvalue() == SAMPLE_BYTES
 
 
-def test_closing():
+def test_closing() -> None:
     reader = jsonlines.Reader([])
     reader.close()
     with pytest.raises(RuntimeError):
@@ -70,7 +70,7 @@ def test_closing():
         writer.write(123)
 
 
-def test_invalid_lines():
+def test_invalid_lines() -> None:
     data = "[1, 2"
     with jsonlines.Reader(io.StringIO(data)) as reader:
         with pytest.raises(jsonlines.InvalidLineError) as excinfo:
@@ -80,7 +80,7 @@ def test_invalid_lines():
         assert exc.line == data
 
 
-def test_skip_invalid():
+def test_skip_invalid() -> None:
     fp = io.StringIO("12\ninvalid\n34")
     reader = jsonlines.Reader(fp)
     it = reader.iter(skip_invalid=True)
@@ -88,7 +88,7 @@ def test_skip_invalid():
     assert next(it) == 34
 
 
-def test_empty_strings_in_iterable():
+def test_empty_strings_in_iterable() -> None:
     input = ["123", "", "456"]
     it = iter(jsonlines.Reader(input))
     assert next(it) == 123
@@ -100,14 +100,14 @@ def test_empty_strings_in_iterable():
     assert list(it) == [123, 456]
 
 
-def test_invalid_utf8():
+def test_invalid_utf8() -> None:
     with jsonlines.Reader([b"\xff\xff"]) as reader:
         with pytest.raises(jsonlines.InvalidLineError) as excinfo:
             reader.read()
         assert "line is not valid utf-8" in str(excinfo.value)
 
 
-def test_empty_lines():
+def test_empty_lines() -> None:
     data_with_empty_line = b"1\n\n2\n"
     with jsonlines.Reader(io.BytesIO(data_with_empty_line)) as reader:
         assert reader.read()
@@ -120,7 +120,7 @@ def test_empty_lines():
         assert list(reader.iter(skip_empty=True)) == [1, 2]
 
 
-def test_typed_reads():
+def test_typed_reads() -> None:
     with jsonlines.Reader(io.StringIO('12\n"foo"\n')) as reader:
         assert reader.read(type=int) == 12
         with pytest.raises(jsonlines.InvalidLineError) as excinfo:
@@ -130,15 +130,15 @@ def test_typed_reads():
         assert exc.line == '"foo"'
 
 
-def test_typed_read_invalid_type():
+def test_typed_read_invalid_type() -> None:
     reader = jsonlines.Reader([])
     with pytest.raises(ValueError) as excinfo:
-        reader.read(type="nope")
+        reader.read(type="nope")  # type: ignore[call-overload]
     exc = excinfo.value
     assert str(exc) == "invalid type specified"
 
 
-def test_typed_iteration():
+def test_typed_iteration() -> None:
     fp = io.StringIO("1\n2\n")
     with jsonlines.Reader(fp) as reader:
         actual = list(reader.iter(type=int))
@@ -153,7 +153,7 @@ def test_typed_iteration():
         assert "does not match requested type" in str(exc)
 
 
-def test_writer_flags():
+def test_writer_flags() -> None:
     fp = io.BytesIO()
     with jsonlines.Writer(fp, compact=True, sort_keys=True) as writer:
         writer.write(
@@ -167,7 +167,7 @@ def test_writer_flags():
     assert fp.getvalue() == b'{"a":1,"b":2}\n'
 
 
-def test_custom_dumps():
+def test_custom_dumps() -> None:
     fp = io.BytesIO()
     writer = jsonlines.Writer(fp, dumps=lambda obj: "oh hai")
     with writer:
@@ -175,13 +175,13 @@ def test_custom_dumps():
     assert fp.getvalue() == b"oh hai\n"
 
 
-def test_custom_loads():
+def test_custom_loads() -> None:
     fp = io.BytesIO(b"{}\n")
     with jsonlines.Reader(fp, loads=lambda s: "uh what") as reader:
         assert reader.read() == "uh what"
 
 
-def test_open_reading():
+def test_open_reading() -> None:
     with tempfile.NamedTemporaryFile("wb") as fp:
         fp.write(b"123\n")
         fp.flush()
@@ -189,7 +189,7 @@ def test_open_reading():
             assert list(reader) == [123]
 
 
-def test_open_writing():
+def test_open_writing() -> None:
     with tempfile.NamedTemporaryFile("w+b") as fp:
         with jsonlines.open(fp.name, mode="w") as writer:
             writer.write(123)
@@ -197,7 +197,7 @@ def test_open_writing():
     assert fp.name in repr(writer)
 
 
-def test_open_and_append_writing():
+def test_open_and_append_writing() -> None:
     with tempfile.NamedTemporaryFile("w+b") as fp:
         with jsonlines.open(fp.name, mode="w") as writer:
             writer.write(123)
@@ -206,7 +206,7 @@ def test_open_and_append_writing():
         assert fp.read() == b"123\n456\n"
 
 
-def test_open_invalid_mode():
+def test_open_invalid_mode() -> None:
     with pytest.raises(ValueError) as excinfo:
         jsonlines.open("foo", mode="foo")
     assert "mode" in str(excinfo.value)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,96 @@
+"""
+This file should give any type checking errors.
+"""
+
+import io
+import json
+import random
+
+import numbers
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
+
+
+if not TYPE_CHECKING:
+
+    def reveal_type(obj: Any) -> None:
+        pass
+
+
+import jsonlines
+
+
+def something_with_reader() -> None:
+
+    reader: jsonlines.Reader
+    reader = jsonlines.Reader(io.StringIO())
+    reader = jsonlines.Reader(io.BytesIO())
+    reader = jsonlines.Reader(['"text"'])
+    reader = jsonlines.Reader([b'"bytes"'])
+
+    r1 = reader.read()
+    r2 = reader.read(allow_none=True)
+    r3: numbers.Number = reader.read(type=random.choice([int, float]))
+
+    # For debugging:
+    # reveal_type(r1)
+    # reveal_type(r2)
+    # reveal_type(r3)
+
+    some_int: int = reader.read(type=int)
+    maybe_int: Optional[int] = reader.read(type=int, allow_none=True)
+
+    some_float: float = reader.read(type=float)
+    maybe_float: Optional[float] = reader.read(type=float, allow_none=True)
+
+    some_bool: bool = reader.read(type=bool)
+    maybe_bool: Optional[bool] = reader.read(type=bool, allow_none=True)
+
+    some_dict: Dict[str, Any] = reader.read(type=dict)
+    optional_dict: Optional[Dict[str, Any]] = reader.read(type=dict, allow_none=True)
+
+    some_list: List[Any] = reader.read(type=list)
+    maybe_list: Optional[List[Any]] = reader.read(type=list, allow_none=True)
+
+    iter_int: Iterable[int] = reader.iter(type=int)
+    iter_str: Iterable[str] = reader.iter(type=str)
+    iter_dict: Iterable[Dict[str, Any]] = reader.iter(type=dict)
+    iter_optional_str: Iterable[Optional[str]] = reader.iter(type=str, allow_none=True)
+
+    locals()  # Silence flake8 F841
+
+
+def something_with_writer() -> None:
+    writer: jsonlines.Writer
+    writer = jsonlines.Writer(io.StringIO())
+    writer = jsonlines.Writer(io.BytesIO())
+
+    locals()  # Silence flake8 F841
+
+
+def something_with_open() -> None:
+    name = "/nonexistent"
+
+    reader: jsonlines.Reader
+    reader = jsonlines.open(name)
+    reader = jsonlines.open(name, "r")
+    reader = jsonlines.open(name, mode="r")
+    reader = jsonlines.open(
+        name,
+        mode="r",
+        loads=json.loads,
+    )
+
+    writer: jsonlines.Writer
+    writer = jsonlines.open(name, "w")
+    writer = jsonlines.open(name, mode="w")
+    writer = jsonlines.open(name, "a")
+    writer = jsonlines.open(
+        name,
+        mode="w",
+        dumps=json.dumps,
+        compact=True,
+        sort_keys=True,
+        flush=True,
+    )
+
+    locals()  # Silence flake8 F841

--- a/tox.ini
+++ b/tox.ini
@@ -11,3 +11,4 @@ deps = -rrequirements-dev.txt
 commands =
   flake8 jsonlines/ tests/
   black --check jsonlines/ tests/
+  mypy --strict jsonlines/ tests/


### PR DESCRIPTION
- Add mypy as a dev dependency, configure it to use all flags that
  --strict also uses (on mypy 0.800), and invoke it from the tox
  ‘linters’ job.

- Add exhaustive type annotations to all classes and functions.

- Add many typing.overload() definitions for Reader.read(),
  Reader.iter(), and open(), to define tighter return types for specific
  argument combinations and values. The result is that a piece of code
  like ‘for d in reader.iter(type=dict)’ will result in ‘d’ being typed
  a a dictionary. (With mypy at least.)

- Add a dependency on ‘attrs’ since it makes writing classes with
  annotated attributes much easier; all classes exposed by this
  library now use it.

- Rewrite all constructor logic and use attrs' ‘post init’ hook for
  anything that needs to be computed upon construction.

- Tweak a few small pieces of code, eg. for detecting and dealing with
  str/bytes IO. (This library support both.)

- Add a test_typing.py file to show the type annotations in action, and
  to catch bugs/regressions.

Closes #59.
