### PR TITLE
Return number of chars/bytes written by Writer.write() and .write_all()

### DIFF
--- a/jsonlines/jsonlines.py
+++ b/jsonlines/jsonlines.py
@@ -507,11 +507,12 @@ class Writer(ReaderWriterBase):
         elif isinstance(sample_dumps_result, bytes) and not self._fp_is_binary:
             self._dumps_result_conversion = DumpsResultConversion.DecodeToString
 
-    def write(self, obj: Any) -> None:
+    def write(self, obj: Any) -> int:
         """
         Encode and write a single object.
 
         :param obj: the object to encode and write
+        :return: number of characters or bytes written
         """
         if self._closed:
             raise RuntimeError("writer is closed")
@@ -532,14 +533,16 @@ class Writer(ReaderWriterBase):
         if self._flush:
             fp.flush()
 
-    def write_all(self, iterable: Iterable[Any]) -> None:
+        return len(line) + 1  # including newline
+
+    def write_all(self, iterable: Iterable[Any]) -> int:
         """
         Encode and write multiple objects.
 
         :param iterable: an iterable of objects
+        :return: number of characters or bytes written
         """
-        for obj in iterable:
-            self.write(obj)
+        return sum(self.write(obj) for obj in iterable)
 
     def _repr_for_wrapped(self) -> str:
         return repr_for_fp(self._fp)

--- a/tests/test_jsonlines.py
+++ b/tests/test_jsonlines.py
@@ -223,7 +223,8 @@ def test_custom_dumps() -> None:
     fp = io.BytesIO()
     writer = jsonlines.Writer(fp, dumps=lambda obj: "oh hai")
     with writer:
-        writer.write({})
+        nbytes = writer.write({})
+        assert nbytes == len(b"oh hai\n")
 
     assert fp.getvalue() == b"oh hai\n"
 
@@ -278,9 +279,11 @@ def test_open_writing() -> None:
 def test_open_and_append_writing() -> None:
     with tempfile.NamedTemporaryFile("w+b") as fp:
         with jsonlines.open(fp.name, mode="w") as writer:
-            writer.write(123)
+            nbytes = writer.write(123)
+            assert nbytes == len(str(123)) + 1
         with jsonlines.open(fp.name, mode="a") as writer:
-            writer.write(456)
+            nbytes = writer.write(456)
+            assert nbytes == len(str(456)) + 1
         assert fp.read() == b"123\n456\n"
 
 


### PR DESCRIPTION
This allows callers to track how much data has been written.

Co-authored-by: wouter bolsterlee <wouter@bolsterl.ee>