### PR TITLE
Support encoder / decoder class

### DIFF
--- a/jsonlines/jsonlines.py
+++ b/jsonlines/jsonlines.py
@@ -192,7 +192,7 @@ class Reader(ReaderWriterBase):
     ]
     _line_iter: Iterator[Tuple[int, Union[bytes, str]]] = attr.ib(init=False)
     _loads: LoadsCallable = attr.ib(default=default_loads, kw_only=True)
-    _cls : type = attr.ib(default=json.JSONDecoder, kw_only=True)
+    _cls : Type[json.JSONDecoder] = attr.ib(default=json.JSONDecoder, kw_only=True)
 
     def __attrs_post_init__(self) -> None:
         if isinstance(self._file_or_iterable, io.IOBase):
@@ -474,7 +474,7 @@ class Writer(ReaderWriterBase):
     _sort_keys: bool = attr.ib(default=False, kw_only=True)
     _flush: bool = attr.ib(default=False, kw_only=True)
     _dumps: DumpsCallable = attr.ib(default=default_dumps, kw_only=True)
-    _cls : type = attr.ib(default=json.JSONEncoder, kw_only=True)
+    _cls : Type[json.JSONEncoder] = attr.ib(default=json.JSONEncoder, kw_only=True)
     _dumps_result_conversion: DumpsResultConversion = attr.ib(
         default=DumpsResultConversion.LeaveAsIs, init=False
     )
@@ -559,6 +559,7 @@ def open(
     mode: Literal["r"] = ...,
     *,
     loads: Optional[LoadsCallable] = ...,
+    cls: Optional[Type[json.JSONDecoder]] = None,
 ) -> Reader:
     ...  # pragma: no cover
 
@@ -569,6 +570,7 @@ def open(
     mode: Literal["w", "a", "x"],
     *,
     dumps: Optional[DumpsCallable] = ...,
+    cls: Optional[Type[json.JSONEncoder]] = None,
     compact: Optional[bool] = ...,
     sort_keys: Optional[bool] = ...,
     flush: Optional[bool] = ...,
@@ -583,6 +585,7 @@ def open(
     *,
     loads: Optional[LoadsCallable] = ...,
     dumps: Optional[DumpsCallable] = ...,
+    cls: Optional[Union[Type[json.JSONEncoder], Type[json.JSONDecoder]]] = None,
     compact: Optional[bool] = ...,
     sort_keys: Optional[bool] = ...,
     flush: Optional[bool] = ...,
@@ -596,7 +599,7 @@ def open(
     *,
     loads: Optional[LoadsCallable] = None,
     dumps: Optional[DumpsCallable] = None,
-    cls: Optional[type] = None,
+    cls: Optional[Union[Type[json.JSONEncoder], Type[json.JSONDecoder]]] = None,
     compact: Optional[bool] = None,
     sort_keys: Optional[bool] = None,
     flush: Optional[bool] = None,


### PR DESCRIPTION
Add `cls` argument to `open()`, `Writer()` and `Reader()`, similarly as in `json.dump`and  `json.load`. 
This can, for example, be used in combination with the NumpyEncoder class from the [numpyencoder](https://pypi.org/project/numpyencoder/) module.

Example code:
```py
import jsonlines
import numpy as np
from numpyencoder import NumpyEncoder

with jsonlines.open('example.jsonl', 'w', cls=NumpyEncoder) as l: 
    l.write(dict(test=np.array([1,2,3]))) 
```

This change is intended as a usability improvement over using 
```py
...
with jsonlines.open('test.jsonl', mode='a', dumps=NumpyEncoder().encode) as l
...
```


## Implementation notes
* The local variable `cls` in `open` had to be renamed to `instance_cls` to prevent confusion. 
* No additional arguments can be supplied to the encoder/decoder, where json.dump, jump.load passes all additional kwargs to the constructor of the encoder/decoder. 